### PR TITLE
Read Supabase JWT from X-Forwarded-Authorization when via gateway

### DIFF
--- a/src/main/java/dev/bored/profile/config/SecurityConfig.java
+++ b/src/main/java/dev/bored/profile/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package dev.bored.profile.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -12,6 +13,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 
@@ -61,7 +63,9 @@ public class SecurityConfig {
                         // Everything else (POST, PUT, DELETE) requires a valid JWT
                         .anyRequest().authenticated()
                 )
-                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .bearerTokenResolver(forwardedFirstBearerResolver())
+                        .jwt(Customizer.withDefaults()))
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .build();
@@ -82,5 +86,42 @@ public class SecurityConfig {
         return NimbusJwtDecoder.withJwkSetUri(jwksUri)
                 .jwsAlgorithm(SignatureAlgorithm.ES256)
                 .build();
+    }
+
+    /**
+     * Resolves the bearer token for Spring Security.
+     * <p>
+     * When routed through the API Gateway on Cloud Run, the {@code Authorization}
+     * header carries the Google-signed OIDC ID token used by Cloud Run for
+     * service-to-service ingress auth — that token is meant for Cloud Run, not
+     * for us. The gateway stashes the caller's original Supabase JWT in
+     * {@code X-Forwarded-Authorization}; we read from that header first so
+     * Spring Security never sees the Google ID token. We fall back to the
+     * standard {@code Authorization} header for local development and any
+     * client that reaches the service without going through the gateway.
+     * </p>
+     *
+     * @return a {@link BearerTokenResolver} that prefers {@code X-Forwarded-Authorization}
+     */
+    @Bean
+    public BearerTokenResolver forwardedFirstBearerResolver() {
+        return request -> {
+            String forwarded = request.getHeader("X-Forwarded-Authorization");
+            if (forwarded != null) {
+                return extractBearer(forwarded);
+            }
+            return extractBearer(request.getHeader(HttpHeaders.AUTHORIZATION));
+        };
+    }
+
+    private static String extractBearer(String headerValue) {
+        if (headerValue == null || headerValue.isBlank()) {
+            return null;
+        }
+        if (!headerValue.regionMatches(true, 0, "Bearer ", 0, 7)) {
+            return null;
+        }
+        String token = headerValue.substring(7).trim();
+        return token.isEmpty() ? null : token;
     }
 }

--- a/src/test/java/dev/bored/profile/config/SecurityConfigTest.java
+++ b/src/test/java/dev/bored/profile/config/SecurityConfigTest.java
@@ -1,0 +1,87 @@
+package dev.bored.profile.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link SecurityConfig#forwardedFirstBearerResolver()}.
+ *
+ * <p>Validates the header-priority contract used by the Cloud Run
+ * service-to-service setup: the gateway puts the Google ID token in the
+ * standard {@code Authorization} header and stashes the caller's Supabase
+ * JWT in {@code X-Forwarded-Authorization}. Spring Security must pick the
+ * forwarded header so it never tries to validate the Google token.</p>
+ */
+class SecurityConfigTest {
+
+    private final BearerTokenResolver resolver = new SecurityConfig().forwardedFirstBearerResolver();
+
+    @Test
+    void resolvesFromForwardedHeader_whenBothHeadersPresent() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("X-Forwarded-Authorization", "Bearer supabase-user-jwt");
+        req.addHeader("Authorization", "Bearer google-id-token");
+
+        assertThat(resolver.resolve(req)).isEqualTo("supabase-user-jwt");
+    }
+
+    @Test
+    void fallsBackToAuthorization_whenNoForwardedHeader() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("Authorization", "Bearer direct-user-jwt");
+
+        assertThat(resolver.resolve(req)).isEqualTo("direct-user-jwt");
+    }
+
+    @Test
+    void returnsNull_whenForwardedHeaderPresentButNotBearer() {
+        // Forwarded header intentionally wins: if it's there but not Bearer,
+        // the caller shouldn't silently fall through to Authorization.
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("X-Forwarded-Authorization", "Basic Zm9vOmJhcg==");
+        req.addHeader("Authorization", "Bearer should-be-ignored");
+
+        assertThat(resolver.resolve(req)).isNull();
+    }
+
+    @Test
+    void returnsNull_whenForwardedHeaderIsBlank() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("X-Forwarded-Authorization", "   ");
+
+        assertThat(resolver.resolve(req)).isNull();
+    }
+
+    @Test
+    void returnsNull_whenNeitherHeaderPresent() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        assertThat(resolver.resolve(req)).isNull();
+    }
+
+    @Test
+    void returnsNull_whenAuthorizationIsNonBearerScheme() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("Authorization", "Basic Zm9vOmJhcg==");
+
+        assertThat(resolver.resolve(req)).isNull();
+    }
+
+    @Test
+    void bearerMatchIsCaseInsensitive() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("X-Forwarded-Authorization", "bearer lowercase-token");
+
+        assertThat(resolver.resolve(req)).isEqualTo("lowercase-token");
+    }
+
+    @Test
+    void returnsNull_whenBearerTokenIsEmpty() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("X-Forwarded-Authorization", "Bearer ");
+
+        assertThat(resolver.resolve(req)).isNull();
+    }
+}


### PR DESCRIPTION
## Why
Locking profile-service with \`--no-allow-unauthenticated\` on Cloud Run means the gateway must attach a Google-signed OIDC ID token in \`Authorization\` for Cloud Run's ingress auth. Cloud Run does not strip that header — it reaches our Spring Security filter, which tries to validate it as a Supabase JWT and 401s every request, even on permit-all GETs.

## What
- Add a \`BearerTokenResolver\` bean that reads from \`X-Forwarded-Authorization\` first (set by the gateway with the user's original Supabase JWT), then falls back to \`Authorization\` for local dev / direct callers.
- Wire the resolver into \`oauth2ResourceServer\`.
- Unit tests for the header-priority contract + common edge cases.

Backward-compatible: direct callers (no gateway) keep working because \`Authorization\` is the fallback.

## Test plan
- [x] \`./gradlew build\` passes locally (including JaCoCo verification)
- [ ] CI green
- [ ] After merge + deploy: verify \`gcloud run services update profile-service --no-allow-unauthenticated\` + end-to-end read through \`api.boredsoftwaredeveloper.xyz\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)