### PR TITLE
Set SUPABASE_DB_HOST + lock service to --no-allow-unauthenticated in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
             --image ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT }}/${{ env.AR_REPO }}/${{ env.SERVICE_NAME }}:${{ github.sha }} \
             --region ${{ env.GCP_REGION }} \
             --platform managed \
-            --allow-unauthenticated \
+            --no-allow-unauthenticated \
             --service-account=${{ env.RUNTIME_SA }} \
             --min-instances=0 \
             --max-instances=2 \
@@ -91,4 +91,4 @@ jobs:
             --concurrency=80 \
             --timeout=60 \
             --set-secrets=DB_USER=DB_USER:latest,DB_PASSWORD=DB_PASSWORD:latest,SUPABASE_URL=SUPABASE_URL:latest \
-            --set-env-vars=LOG_FORMAT=ecs
+            --set-env-vars=LOG_FORMAT=ecs,SUPABASE_DB_HOST=aws-1-ap-southeast-2.pooler.supabase.com


### PR DESCRIPTION
## Why
Last deploy crashed at startup because \`--set-env-vars\` in the deploy step replaces the whole env set, wiping my manual \`SUPABASE_DB_HOST\` override (pooler). Startup then went to the IPv6-only direct DB host from application.yml and Flyway couldn't open a socket.

## What
- Add \`SUPABASE_DB_HOST=aws-1-ap-southeast-2.pooler.supabase.com\` to the \`--set-env-vars\` list.
- Flip \`--allow-unauthenticated\` → \`--no-allow-unauthenticated\`. The service is only reachable via the API gateway now (\`cloud-run-runtime\` SA has \`run.invoker\`); the gateway attaches a Google OIDC ID token on every downstream call and stashes the user JWT in \`X-Forwarded-Authorization\`, which we read via \`BearerTokenResolver\` (merged in #6).

## Test plan
- [ ] CI deploys successfully
- [ ] After gateway redeploy, \`GET /api/v1/profiles/1\` via \`api.boredsoftwaredeveloper.xyz\` returns 200
- [ ] Direct hit to service URL returns 403 (locked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)