### PR TITLE
chore(cache): bump Redis TTL to 7 days

### DIFF
--- a/src/main/java/dev/bored/profile/config/CacheConfig.java
+++ b/src/main/java/dev/bored/profile/config/CacheConfig.java
@@ -63,7 +63,7 @@ public class CacheConfig {
                         JsonTypeInfo.As.PROPERTY);
         GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(mapper);
         RedisCacheConfiguration jsonConfig = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofMinutes(5))
+                .entryTtl(Duration.ofDays(7))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer));
         return builder -> builder.cacheDefaults(jsonConfig);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,9 +7,11 @@ spring:
 
   # ── Redis + Cache (optional) ─────────────────────────────────────
   # When REDIS_HOST is set, Spring auto-configures Lettuce + RedisCacheManager
-  # with a 5-minute default TTL. When REDIS_HOST is unset (local dev) we
-  # exclude both Redis auto-configs via SPRING_AUTOCONFIGURE_EXCLUDE so no
-  # connection is attempted; @Cacheable still works via the fallback
+  # with a 7-day default TTL — profile data changes rarely and mutations call
+  # @CacheEvict, so a long TTL costs us almost nothing in staleness and saves
+  # a lot on Upstash commands. When REDIS_HOST is unset (local dev) we exclude
+  # both Redis auto-configs via SPRING_AUTOCONFIGURE_EXCLUDE so no connection
+  # is attempted; @Cacheable still works via the fallback
   # ConcurrentMapCacheManager.
   autoconfigure:
     exclude: ${SPRING_AUTOCONFIGURE_EXCLUDE:org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration}
@@ -28,7 +30,7 @@ spring:
           min-idle: 0
   cache:
     redis:
-      time-to-live: 300s   # 5 min default TTL for all caches
+      time-to-live: 7d     # 7 days — evicted on write; long TTL = fewer Upstash commands
       cache-null-values: false
       use-key-prefix: true
       key-prefix: "profile-svc::"


### PR DESCRIPTION
## Summary
- Bumps the default Spring Cache Redis TTL from 5 min to 7 days
- Touches `application.yml` (`spring.cache.redis.time-to-live`) and `CacheConfig.java` (`RedisCacheConfiguration.entryTtl`) — both set to keep the two sources of truth aligned, even though the code `entryTtl` is what actually wins at runtime

## Why
Profile data almost never changes. Every mutating path (`POST/PUT/DELETE`) already calls `@CacheEvict`, so a long TTL never serves stale data — it just keeps warm entries from expiring and forcing DB round-trips on the next read. This is purely a cost/traffic optimization against Upstash's 10K-commands/day free tier.

## Tradeoffs
- Worst-case staleness remains bounded by our `@CacheEvict` coverage, not by TTL. If a cache-key scheme ever drifts from the eviction key, stale data could linger up to 7 days — worth watching when we add new cached methods.
- Cold-start cost is unchanged (first read after deploy still hits the DB).
- Cache memory usage goes up slightly (entries live longer) but profile data is tiny — well inside Upstash's 256 MB free tier.

## Test plan
- [ ] CI green (JaCoCo ≥ 0.90)
- [ ] Post-merge: deploy to Cloud Run, hit `/api/v1/profiles/1`, `/api/v1/experiences?profileId=1` and confirm successive calls don't re-hit Postgres (check Supabase dashboard)